### PR TITLE
Translated "Précommander"

### DIFF
--- a/english/site/index_en.json
+++ b/english/site/index_en.json
@@ -180,7 +180,7 @@
     },
     {
       "to_translate": "Précommander",
-      "translation": "",
+      "translation": "Preorder",
     },
     {
       "to_translate": "Prochainement",


### PR DESCRIPTION
J'ai traduit le mot précommander qui n'était pas traduit.